### PR TITLE
Fix a bug  "Answer Without Revealing" in web

### DIFF
--- a/src/components/Deck/Deck.js
+++ b/src/components/Deck/Deck.js
@@ -117,7 +117,11 @@ const Deck = ({
   }, [
     revealed,
     swipeLock,
-    offscreen
+    offscreen,
+    allowSkipping,
+    useReveal,
+    triggerSwipeLeft,
+    triggerSwipeRight
   ])
 
   return (


### PR DESCRIPTION
Fix #59 
The problem was caused because **triggerSwipeLeft** and **triggerSwipeRight** weren't updated in **eventListener**