### PR TITLE
Make link to website work in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Juken is a cross-platform application, available natively on mobile platforms an
 
 ### Web
 
-Juken is available on the web, and it is optimized for the desktop experience. You can do your reviews using only your keyboard; space to reveal the answer and arrow keys to submit instead of the swipe gestures (although gestures are still available for touch screen devices using the web app). Juken is also optimized for the mobile web. You can go to [juken.io](juken.io) on your mobile browser and have a decent review experience (although native apps offers a much superior experience and are recommended).
+Juken is available on the web, and it is optimized for the desktop experience. You can do your reviews using only your keyboard; space to reveal the answer and arrow keys to submit instead of the swipe gestures (although gestures are still available for touch screen devices using the web app). Juken is also optimized for the mobile web. You can go to [juken.io](https://juken.io) on your mobile browser and have a decent review experience (although native apps offers a much superior experience and are recommended).
 
 <a href="https://juken.io" target="_new">
   <img src="https://user-images.githubusercontent.com/2817993/82254164-08fb9300-995b-11ea-9637-6ac42e78359e.png" height="40" alt="Juken Web">
@@ -82,7 +82,7 @@ Juken is available on the web, and it is optimized for the desktop experience. Y
 
 ### Progressive Web App (PWA)
 
-Juken has PWA support on [juken.io](juken.io), so you can install it and use it like a desktop application. [Here's](https://support.google.com/chrome/answer/9658361) a guide on how to install PWAs on Chrome, and note that most major browsers have support for PWAs.
+Juken has PWA support on [juken.io](https://juken.io), so you can install it and use it like a desktop application. [Here's](https://support.google.com/chrome/answer/9658361) a guide on how to install PWAs on Chrome, and note that most major browsers have support for PWAs.
 
 ### Expo
 


### PR DESCRIPTION
Currently GitHub interprets the link as an internal GitHub link instead of an external URL.