### PR TITLE
Add mnemonics to reviews

### DIFF
--- a/src/components/Card/Card.js
+++ b/src/components/Card/Card.js
@@ -89,7 +89,7 @@ const Card = ({
             }
           />
           <TouchableWithoutFeedback onPress={onCardPressed}>
-            <View style={{height: "100%", flexGrow: 1}}>
+            <View style={{height: "100%", flexGrow: 1, outline: 'none'}}>
               {/* question and question statement */}
               <Question
                   revealed={revealed}

--- a/src/components/Card/Card.js
+++ b/src/components/Card/Card.js
@@ -28,9 +28,6 @@ const DirectionRightIcon = () => (
   </View>
 );
 
-const ConditionalWrapper = ({ condition, wrapper, children }) =>
-    condition ? wrapper(children) : children;
-
 const Card = ({
   empty,
   deckProps = {},
@@ -39,12 +36,16 @@ const Card = ({
   reviewQuestion,
   reviewQuestionComponent,
   reviewAnswer,
+  meaningMnemonic,
+  readingMnemonic,
   quickMode
 }) => {
 
   const {
     reveal,
     revealed,
+    toggleMnemonic,
+    mnemonicToggled,
     isFirstCard,
     getClearInterpolation,
   } = deckProps;
@@ -56,11 +57,15 @@ const Card = ({
   }
 
   const onCardPressed = () =>{
-    // Medium haptic feedback feels the best
-    if (device('mobile')) {
-      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy)
+    if (revealed) {
+      toggleMnemonic()
+    } else if (quickMode) { // Reveal answer on press only if quick mode is on
+      // Medium haptic feedback feels the best
+      if (device('mobile')) {
+        Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy)
+      }
+      reveal()
     }
-    reveal()
   }
 
   return (
@@ -83,33 +88,33 @@ const Card = ({
               : (TERMINOLOGY[subjectType] || '')
             }
           />
-        {/* Use the TouchableWithoutFeedback only when the card is not revealed and quickmode is on */}
-        <ConditionalWrapper
-            condition={!revealed && quickMode}
-            wrapper={children => <TouchableWithoutFeedback onPress={onCardPressed}>{children}</TouchableWithoutFeedback>}>
-          <View style={{height: "100%", flexGrow: 1}}>
-            {/* question and question statement */}
-            <Question
-                revealed={revealed}
-                answer={reviewAnswer}
-                question={reviewQuestion}
-                questionComponent={reviewQuestionComponent}
-                reviewType={reviewType}
-                subjectType={subjectType}
-            />
+          <TouchableWithoutFeedback onPress={onCardPressed}>
+            <View style={{height: "100%", flexGrow: 1}}>
+              {/* question and question statement */}
+              <Question
+                  revealed={revealed}
+                  mnemonicToggled={mnemonicToggled}
+                  answer={reviewAnswer}
+                  question={reviewQuestion}
+                  questionComponent={reviewQuestionComponent}
+                  reviewType={reviewType}
+                  subjectType={subjectType}
+                  meaningMnemonic={meaningMnemonic}
+                  readingMnemonic={readingMnemonic}
+              />
 
-            {/* reveal button */}
-            <View style={{height: 52}}>
-              {!revealed && !quickMode && (
-                  <LongPressButton
-                      text="Reveal"
-                      flashText={`Press and Hold${device('web') ? ' / Spacebar' : ''}`}
-                      onComplete={reveal}
-                  />
-              )}
+              {/* reveal button */}
+              <View style={{height: 52}}>
+                {!revealed && !quickMode && (
+                    <LongPressButton
+                        text="Reveal"
+                        flashText={`Press and Hold${device('web') ? ' / Spacebar' : ''}`}
+                        onComplete={reveal}
+                    />
+                )}
+              </View>
             </View>
-          </View>
-        </ConditionalWrapper>
+          </TouchableWithoutFeedback>
       </View>
 
     </View>
@@ -124,6 +129,8 @@ Card.propTypes = {
   reviewQuestion: PropTypes.string,
   reviewQuestionComponent: PropTypes.any,
   reviewAnswer: PropTypes.string,
+  meaningMnemonic: PropTypes.string,
+  readingMnemonic: PropTypes.string,
   quickMode: PropTypes.bool,
 };
 

--- a/src/components/Card/Question.js
+++ b/src/components/Card/Question.js
@@ -11,6 +11,8 @@ import {
 } from 'src/common/constants';
 import useColorScheme from 'src/hooks/useColorScheme';;
 
+import TextWithMarkups from 'src/components/TextWithMarkups/TextWithMarkups';
+
 const Question = ({
   subjectType,
   reviewType,
@@ -18,6 +20,9 @@ const Question = ({
   questionComponent,
   answer,
   revealed,
+  mnemonicToggled,
+  meaningMnemonic,
+  readingMnemonic
 }) => {
   const colorScheme = useColorScheme();
   return (
@@ -39,7 +44,7 @@ const Question = ({
       <View style={[styles.separator, colorScheme === "light" ? null : styles.separator_dark]}/>
 
       {/* answer */}
-      <View style={styles.answer}>
+      {!mnemonicToggled && <View style={styles.answer}>
         <Text
           style={[
             styles.answerText,colorScheme === "light" ? null : styles.answerText_Dark,
@@ -53,7 +58,11 @@ const Question = ({
           {revealed && answer}
           {!revealed && TERMINOLOGY[reviewType]}
         </Text>
-      </View>
+      </View>}
+      
+      {mnemonicToggled && <View>
+        <TextWithMarkups text={reviewType === READING ? readingMnemonic : meaningMnemonic} />
+      </View>}
 
     </View>
   );
@@ -64,6 +73,9 @@ Question.propTypes = {
   question: PropTypes.string,
   answer: PropTypes.string,
   revealed: PropTypes.bool,
+  mnemonicToggled: PropTypes.bool,
+  meaningMnemonic: PropTypes.string,
+  readingMnemonic: PropTypes.string,
 };
 
 const styles = StyleSheet.create({

--- a/src/components/Card/Question.js
+++ b/src/components/Card/Question.js
@@ -9,7 +9,9 @@ import {
   READING,
   TERMINOLOGY,
 } from 'src/common/constants';
-import useColorScheme from 'src/hooks/useColorScheme';;
+import useColorScheme from 'src/hooks/useColorScheme';
+
+import device from 'src/utils/device';
 
 import TextWithMarkups from 'src/components/TextWithMarkups/TextWithMarkups';
 
@@ -55,11 +57,21 @@ const Question = ({
             ),
           ]}
         >
+          {/* answer itself */}
           {revealed && answer}
+
+          {/* review type */}
           {!revealed && TERMINOLOGY[reviewType]}
+
+          {/* mnemic toggle hint */}
+          {revealed && <Text style={styles.mnemonicHint}>
+            {/* one new line is sufficient with readings as the answer font adds enough vertical space by itself */}
+            {reviewType === READING ? '\n' : '\n\n'} 
+            {device('web') ? 'Press space for mnemonic' : 'Tap for mnemonic'}
+          </Text>}
         </Text>
       </View>}
-      
+
       {mnemonicToggled && <View>
         <TextWithMarkups text={reviewType === READING ? readingMnemonic : meaningMnemonic} />
       </View>}
@@ -124,6 +136,11 @@ const styles = StyleSheet.create({
   },
   answerTextLarge: {
     fontSize: 20
+  },
+  mnemonicHint: {
+    opacity: 0.4,
+    fontSize: 14,
+    fontWeight: 400,
   },
   [KANJI]: { color: theme.color.kanji },	
   [RADICAL]: { color: theme.color.radical },	

--- a/src/components/Deck/Deck.js
+++ b/src/components/Deck/Deck.js
@@ -116,6 +116,7 @@ const Deck = ({
     event: 'keydown',
     handler: e => {
       if (e.code === 'Space' && !revealed) useReveal();
+      if (e.code === 'Space' && revealed) useMnemonicToggle();
       if (!allowSkipping && swipeLock) return;
       if (e.key === 'ArrowLeft' || e.code === 'ArrowLeft') triggerSwipeLeft();
       if (e.key === 'ArrowRight' || e.code === 'ArrowRight') triggerSwipeRight();

--- a/src/components/Deck/Deck.js
+++ b/src/components/Deck/Deck.js
@@ -40,6 +40,7 @@ const Deck = ({
 
   // deck size
   const [revealed, setRevealed] = useState(false);
+  const [mnemonicToggled, setMnemonicToggled] = useState(false);
   const [swipeLock, setSwipeLock] = useState(true);
   const [deckWidth, setDeckWidth] = useState(null);
   const [deckHeight, setDeckHeight] = useState(null);
@@ -47,6 +48,7 @@ const Deck = ({
   // control dismiss of the top card
   const useDismiss = direction => {
     setRevealed(false);
+    setMnemonicToggled(false);
     setSwipeLock(!allowSkipping);
     dismissCard(direction);
   }
@@ -55,6 +57,10 @@ const Deck = ({
   const useReveal = () => {
     setRevealed(true);
     setSwipeLock(false);
+  }
+
+  const useMnemonicToggle = () => {
+    setMnemonicToggled(!mnemonicToggled);
   }
 
   // calculate coordinates which cards
@@ -166,6 +172,8 @@ const Deck = ({
                 getMovementInterpolation,
                 reveal: useReveal,
                 revealed: isFirstCard && revealed,
+                toggleMnemonic: useMnemonicToggle,
+                mnemonicToggled: isFirstCard && mnemonicToggled,
               })}
           </Animated.View>
         );

--- a/src/components/TextWithMarkups/TextWithMarkups.js
+++ b/src/components/TextWithMarkups/TextWithMarkups.js
@@ -9,8 +9,10 @@ import {
   READING,
   MEANING,
 } from 'src/common/constants';
+import useColorScheme from 'src/hooks/useColorScheme';;
 
 const TextWithMarkups = ({ text = "", style = [] }) => {
+  const colorScheme = useColorScheme();
 
   // "lorem <radical>ipsum</radical> dolor sit amet!"
   // ["lorem", "<radical>", "ipsum", "dolor", "sit", "amet!"]
@@ -32,6 +34,7 @@ const TextWithMarkups = ({ text = "", style = [] }) => {
             style={[
               ...style,
               styles.base,
+              colorScheme === "light" ? null : styles.base_dark,
               parts[i - 1] === '<radical>' ? styles[RADICAL] : null,
               parts[i - 1] === '<kanji>' ? styles[KANJI] : null,
               parts[i - 1] === '<vocabulary>' ? styles[VOCAB] : null,
@@ -56,6 +59,9 @@ const styles = StyleSheet.create({
   base: {
     lineHeight: 20,
     borderRadius: 4,
+  },
+  base_dark: {
+    color: theme.palette.white,
   },
   [KANJI]: {
     backgroundColor: theme.color.kanji,

--- a/src/components/TextWithMarkups/TextWithMarkups.js
+++ b/src/components/TextWithMarkups/TextWithMarkups.js
@@ -31,6 +31,7 @@ const TextWithMarkups = ({ text = "", style = [] }) => {
           <Text
             style={[
               ...style,
+              styles.base,
               parts[i - 1] === '<radical>' ? styles[RADICAL] : null,
               parts[i - 1] === '<kanji>' ? styles[KANJI] : null,
               parts[i - 1] === '<vocabulary>' ? styles[VOCAB] : null,
@@ -52,25 +53,39 @@ TextWithMarkups.propTypes = {
 };
 
 const styles = StyleSheet.create({
+  base: {
+    lineHeight: 20,
+    borderRadius: 4,
+  },
   [KANJI]: {
     backgroundColor: theme.color.kanji,
     color: theme.palette.white,
+    paddingVertical: 1,
+    paddingHorizontal: 2,
   },
   [VOCAB]: {
     backgroundColor: theme.color.vocab,
     color: theme.palette.white,
+    paddingVertical: 1,
+    paddingHorizontal: 2,
   },
   [RADICAL]: {
     backgroundColor: theme.color.radical,
     color: theme.palette.white,
+    paddingVertical: 1,
+    paddingHorizontal: 2,
   },
   [READING]: {
     backgroundColor: theme.color.githubBlack,
     color: theme.palette.white,
+    paddingVertical: 1,
+    paddingHorizontal: 2,
   },
   [MEANING]: {
     backgroundColor: theme.color.githubBlack,
     color: theme.palette.white,
+    paddingVertical: 1,
+    paddingHorizontal: 2,
   },
 })
 

--- a/src/screens/Review/Review.js
+++ b/src/screens/Review/Review.js
@@ -200,6 +200,8 @@ const Review = ({ demo = false, stopDemo } = {}) => {
               const subjectId = _.get(review, 'data.subject_id');
               const subject = _.get(subjectsDict, subjectId);
               const subjectType = _.get(subject, 'object');
+              const meaningMnemonic = _.get(subject, 'data.meaning_mnemonic');
+              const readingMnemonic = _.get(subject, 'data.reading_mnemonic');
               const {
                 question,
                 questionComponent,
@@ -215,6 +217,8 @@ const Review = ({ demo = false, stopDemo } = {}) => {
                   reviewQuestion={question}
                   reviewQuestionComponent={questionComponent}
                   reviewAnswer={answer}
+                  meaningMnemonic={meaningMnemonic}
+                  readingMnemonic={readingMnemonic}
                   quickMode={quickMode}
                 />
               )


### PR DESCRIPTION
This PR adds a "3rd face" to the review cards, that can be toggled on/off via a tap after the answer has been revealed, as mentioned in #68. Also makes some visual improvements to the `TextWithMarkups` component (as can be seen in the screenshot below).

I believe showing mnemonics only is enough for this app — keeps it simple. They cover the scenario where you fail to recall a review item and the answer alone isn't enough to jog your memory. Most users likely use Juken supplementary to another app and so they can look up extra information such as sample sentences there. 

<img width="411" alt="Screen Shot 2021-06-27 at 2 00 49 PM" src="https://user-images.githubusercontent.com/2550945/123543928-29e30a00-d751-11eb-8f15-954dae5220d7.png">

### Considerations:
1. ~~Releasing a card before activation threshold in either direction causes a tap event to be handled and thus toggles the mnemonic.~~ This seems to be a problem only on the web if you are dragging with a mouse. Probably not a big deal.
2. This feature isn't exactly obvious to the user. Might want to add a hint.
3. ~~The experience on the web (with a keyboard) hasn't been considered thoroughly. Maybe it can work similarly to mobile and toggle on spacebar press.~~ Done.

These are things I'd like to iron out before I call this feature complete but wanted to hear your thoughts first.